### PR TITLE
Response object attributes update

### DIFF
--- a/lib/spare5-ruby/response.rb
+++ b/lib/spare5-ruby/response.rb
@@ -1,6 +1,6 @@
 module Spare5
   class Response
-    ATTRIBUTES = [:job_id, :job_batch_id, :question_id, :user_id, :response, :reference_id, :created_at]
+    ATTRIBUTES = [:job_id, :job_batch_id, :question_id, :user_id, :response, :reference_id, :created_at, :num_responders, :num_completed, :best_response, :best_score]
 
     attr_accessor *ATTRIBUTES
 


### PR DESCRIPTION
The raw `responses` API response reflects a different structure than what is defined in the `Response` object. Currently, `job_id`, `job_batch_id`, `question_id`, `user_id`, `response`, and `created_at` are all returning `nil`.

This commit adds `num_responders`, `num_completed`, `best_response`, and `best_score` to the `Response` object to reflect the data provided by the API. The attributes mentioned above that are returning `nil` have been left in, just in case they are being returned in other cases.

The following API endpoint was referenced for this change:
`https://app.spare5.com/partner/v2/job_batches/:batch_id/jobs/:job_id/responses`