### PR TITLE
Properly handle Spare5::Job objects passed into create_job

### DIFF
--- a/lib/spare5-ruby/job_batch.rb
+++ b/lib/spare5-ruby/job_batch.rb
@@ -30,7 +30,12 @@ module Spare5
     end
 
     def create_job(job_or_job_params, raise_on_error = false)
-      job = Job.new(job_or_job_params) if job_or_job_params.is_a?(Hash)
+      if job_or_job_params.is_a?(Spare5::Job)
+        job = job_or_job_params
+      else
+        job = Job.new(job_or_job_params)
+      end
+
       job.validate!(self.job_type)
 
       response = Connection.send_request(:post, raise_on_error, self.url + "/jobs", job.to_json)


### PR DESCRIPTION
The `demo.rb` file shows a `Spare5::StarRatingJob` object being passed into the `create_job` method. There is a bug that prevents a non-hash from being properly parsed by this method..

This commit fixes that by properly handling both `Hash` and `Spare5::Job` objects being passed into the `create_job` method.